### PR TITLE
replace class name generation with doctrine/inflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
     ],
     "autoload": {
         "psr-4": {"baltpeter\\Internetmarke\\": "src/baltpeter/Internetmarke"}
+    },
+    "require": {
+        "doctrine/inflector": "^1.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,5 @@
     ],
     "autoload": {
         "psr-4": {"baltpeter\\Internetmarke\\": "src/baltpeter/Internetmarke"}
-    },
-    "require": {
-        "doctrine/inflector": "^1.3"
     }
 }

--- a/src/baltpeter/Internetmarke/ApiResult.php
+++ b/src/baltpeter/Internetmarke/ApiResult.php
@@ -9,11 +9,10 @@ abstract class ApiResult {
         $object = new $class_name(...array_fill(0, ((new \ReflectionMethod($class_name, '__construct'))->getNumberOfParameters()), null));
 
         foreach($std_object as $property => $value) {
-            // taken from http://stackoverflow.com/a/19533226
-            $snake_property = ltrim(strtolower(preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '_$0', $property)), '_');
+            $snake_property = \Doctrine\Common\Inflector\Inflector::tableize($property);
 
             if(is_object($value)) {
-                $value_class_name = __NAMESPACE__ . '\\' . $property;
+                $value_class_name = __NAMESPACE__ . '\\' . \Doctrine\Common\Inflector\Inflector::classify($property);
                 if(class_exists($value_class_name) && is_subclass_of($value_class_name, get_class())) {
                     $value = $value_class_name::fromStdObject($value);
                 }

--- a/src/baltpeter/Internetmarke/ApiResult.php
+++ b/src/baltpeter/Internetmarke/ApiResult.php
@@ -9,10 +9,12 @@ abstract class ApiResult {
         $object = new $class_name(...array_fill(0, ((new \ReflectionMethod($class_name, '__construct'))->getNumberOfParameters()), null));
 
         foreach($std_object as $property => $value) {
-            $snake_property = \Doctrine\Common\Inflector\Inflector::tableize($property);
+            // taken from https://github.com/doctrine/inflector by the Doctrine Project, Inflector::tableize()
+            $snake_property = mb_strtolower(preg_replace('~(?<=\\w)([A-Z])~u', '_$1', $property));
 
             if(is_object($value)) {
-                $value_class_name = __NAMESPACE__ . '\\' . \Doctrine\Common\Inflector\Inflector::classify($property);
+                // taken from https://github.com/doctrine/inflector by the Doctrine Project, Inflector::classify()
+                $value_class_name = __NAMESPACE__ . '\\' . str_replace([' ', '_', '-'], '', ucwords($property, ' _-'));
                 if(class_exists($value_class_name) && is_subclass_of($value_class_name, get_class())) {
                     $value = $value_class_name::fromStdObject($value);
                 }


### PR DESCRIPTION
I had the problem that sometimes the classnames have not been generated correctly. The first character was lowercase. It should be replaced by a bulletproof method.