### PR TITLE
Closes #8 add unzip feature to return object for checkoutShoppingCartPng

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 This project’s main purpose is to be able to order Deutsche Post stamps directly from your own applications. The payment is handled via the Portokasse, a prepaid wallet service also by Deutsche Post.
 
-The web service by Deutsche Post is a custom SOAP API (see the WSDL here: https://internetmarke.deutschepost.de/OneClickForAppV3?wsdl). This project aims to abstract the SOAP nature away and provide a PHP API, while still adhering to the structure defined by DPAG.  
+The web service by Deutsche Post is a custom SOAP API (see the WSDL here: https://internetmarke.deutschepost.de/OneClickForAppV3?wsdl). This project aims to abstract the SOAP nature away and provide a PHP API, while still adhering to the structure defined by DPAG.
 Do note that this is only a very thin wrapper around the SOAP API and the user still has to follow DPAG’s [specification](https://www.deutschepost.de/de/i/internetmarke-porto-drucken/downloads.html).
 
 ## Requirements
 
-To access the web service, you will need to register as a partner with DPAG. This can either be done via their [website](https://www.deutschepost.de/de/i/internetmarke-porto-drucken/geschaeftskunden.html) (German only) or by contacting pcf-1click@deutschepost.de.  
+To access the web service, you will need to register as a partner with DPAG. This can either be done via their [website](https://www.deutschepost.de/de/i/internetmarke-porto-drucken/geschaeftskunden.html) (German only) or by contacting pcf-1click@deutschepost.de.
 They will send you the documentation for the web service and create your personal credentials (consisting of: your partner ID, a secret key called `SCHLUESSEL_DPWN_MARKTPLATZ`, and a key phase which is usually `1`).
 
-In addition, you will need to have an account for the [Portokasse service](https://portokasse.deutschepost.de/portokasse/#!/). This is a prepaid wallet from which your purchase totals will be deducted.  
+In addition, you will need to have an account for the [Portokasse service](https://portokasse.deutschepost.de/portokasse/#!/). This is a prepaid wallet from which your purchase totals will be deducted.
 After registering, you can access the service with your username (email address) and password.
 
 ## Installation
@@ -46,9 +46,9 @@ $order_item = new \baltpeter\Internetmarke\OrderItem(1, null, null,
 
 // Finally, we call `checkoutShoppingCartPdf()` which creates the order and actually
 // deducts the money from your Portokasse.
-// The last parameter in this example is the total cost, which you have to calculate
+// The last parameter in this example is the total cost in eurocents, which you have to calculate
 // manually. This value *has* to be correct, it is checked on the server side.
-var_dump($service->checkoutShoppingCartPdf($user_token, 1, array($order_item), 70));
+var_dump($service->checkoutShoppingCartPdf($user_token, 1, array($order_item), 80));
 ```
 
 Running this code will print a result similar to this:

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 ![Ordering a stamp using internetmarke-php](https://cdn.baltpeter.io/img/internetmarke-php-hero.svg)
 
-This project’s main purpose is to be able to order Deutsche Post stamps directly from your own applications. The payment is handled via the Portokasse, a prepaid wallet service also by Deutsche Post.
+This project’s main purpose is to be able to order Deutsche Post stamps directly from your own applications. The payment is handled via the Portokasse, a prepaid wallet service also by Deutsche Post.  
 
 The web service by Deutsche Post is a custom SOAP API (see the WSDL here: https://internetmarke.deutschepost.de/OneClickForAppV3?wsdl). This project aims to abstract the SOAP nature away and provide a PHP API, while still adhering to the structure defined by DPAG.
 Do note that this is only a very thin wrapper around the SOAP API and the user still has to follow DPAG’s [specification](https://www.deutschepost.de/de/i/internetmarke-porto-drucken/downloads.html).
 
 ## Requirements
 
-To access the web service, you will need to register as a partner with DPAG. This can either be done via their [website](https://www.deutschepost.de/de/i/internetmarke-porto-drucken/geschaeftskunden.html) (German only) or by contacting pcf-1click@deutschepost.de.
+To access the web service, you will need to register as a partner with DPAG. This can either be done via their [website](https://www.deutschepost.de/de/i/internetmarke-porto-drucken/geschaeftskunden.html) (German only) or by contacting pcf-1click@deutschepost.de.  
 They will send you the documentation for the web service and create your personal credentials (consisting of: your partner ID, a secret key called `SCHLUESSEL_DPWN_MARKTPLATZ`, and a key phase which is usually `1`).
 
-In addition, you will need to have an account for the [Portokasse service](https://portokasse.deutschepost.de/portokasse/#!/). This is a prepaid wallet from which your purchase totals will be deducted.
+In addition, you will need to have an account for the [Portokasse service](https://portokasse.deutschepost.de/portokasse/#!/). This is a prepaid wallet from which your purchase totals will be deducted.  
 After registering, you can access the service with your username (email address) and password.
 
 ## Installation

--- a/src/baltpeter/Internetmarke/Service.php
+++ b/src/baltpeter/Internetmarke/Service.php
@@ -160,7 +160,7 @@ class Service extends \SoapClient {
             'userToken' => $user_token, 'shopOrderId' => $shop_order_id, 'ppl' => $ppl_id, 'positions' => $positions,
             'total' => $total, 'createManifest' => $create_manifest, 'createShippingList' => $create_shipping_list
         )));
-        return $result;
+        return StampPngResult::fromStdObject($result);
     }
 
     /**

--- a/src/baltpeter/Internetmarke/StampPngResult.php
+++ b/src/baltpeter/Internetmarke/StampPngResult.php
@@ -25,6 +25,7 @@ class StampPngResult extends ApiResult {
    * @param string $link           url to zipfile
    * @param integer $walletBallance portokasse balance in eurocent
    * @param stdClass $shoppingCart   with attributes `shopOrderId` and `voucherList`
+   * @param string url to posting receipt of order
    */
   public function __construct($link, $walletBallance, $shoppingCart, $manifestLink = null) {
       $this->link           = $link;
@@ -66,6 +67,7 @@ class StampPngResult extends ApiResult {
         file_put_contents($path . $filename, $data);
         $files[]  = $filename;
       }
+
       unlink($tempFile);
       return $files;
   }

--- a/src/baltpeter/Internetmarke/StampPngResult.php
+++ b/src/baltpeter/Internetmarke/StampPngResult.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace baltpeter\Internetmarke;
+
+class StampPngResult extends ApiResult {
+  /**
+   * @var string url to zipfile
+   */
+  public $link;
+  /**
+   * @var integer portokasse balance in eurocent
+   */
+  public $walletBallance;
+  /**
+   * @var stdClass with attributes `shopOrderId` and `voucherList`
+   */
+  public $shoppingCart;
+
+  /**
+   *
+   * @param string $link           url to zipfile
+   * @param integer $walletBallance portokasse balance in eurocent
+   * @param stdClass $shoppingCart   with attributes `shopOrderId` and `voucherList`
+   */
+  public function __construct($link, $walletBallance, $shoppingCart) {
+      $this->link           = $link;
+      $this->walletBallance = $walletBallance;
+      $this->shoppingCart   = $shoppingCart;
+  }
+
+  /**
+   * Store zip and png files in folder of $path
+   * @param string $path location where png should be extracted to
+   * @return array filenames of png's that were extracted
+   */
+  public function unzipPNG($path)
+  {
+      // make sure $path ends with slash
+      $path = rtrim($path, '/') . '/';
+
+      if(!file_exists($path)){
+        mkdir($path);
+      }
+
+      $tempFile = $path . 'zip' . date('Y-m-d_H:i:s'). '_' . uniqid();
+      copy($this->link,$tempFile);
+
+      $zip = new \ZipArchive();
+      $zip->open($tempFile);
+      $file_count = $zip->count();
+      $files = [];
+      for ($i=0; $i < $file_count; $i++) {
+        $data     = $zip->getFromIndex($i);
+        $filename = date('Y-m-d_H:i:s'). '_' . uniqid() . '.png';
+        file_put_contents($path . $filename, $data);
+        $files[]  = $filename;
+      }
+
+      return $files;
+  }
+
+}


### PR DESCRIPTION
The class has no setter or getter methods, because the attributes have to remain public anyway to ensure backwards compatibility. 

