### PR TITLE
PHP 8.3 compatibility: Replace get_class() with __CLASS__

### DIFF
--- a/src/baltpeter/Internetmarke/ApiResult.php
+++ b/src/baltpeter/Internetmarke/ApiResult.php
@@ -16,7 +16,7 @@ abstract class ApiResult {
                 if(is_object($value)) {
                     // taken from https://github.com/doctrine/inflector by the Doctrine Project, Inflector::classify()
                     $value_class_name = __NAMESPACE__ . '\\' . str_replace([' ', '_', '-'], '', ucwords($property, ' _-'));
-                    if(class_exists($value_class_name) && is_subclass_of($value_class_name, get_class())) {
+                    if(class_exists($value_class_name) && is_subclass_of($value_class_name, __CLASS__)) {
                         $value = $value_class_name::fromStdObject($value);
                     }
                 }


### PR DESCRIPTION
Hi there,

I was just testing the library with PHP 8.3 and found calling get_class() without arguments is deprecated. Added a patch and replaced the call with __CLASS__ instead.

Best,
Dennis